### PR TITLE
Limit/Offset pagination for latest n entries

### DIFF
--- a/src/models/FeedDataModel.py
+++ b/src/models/FeedDataModel.py
@@ -57,8 +57,8 @@ class FeedDataModel(db.Model):
             limit).all()
 
     @staticmethod
-    def get_latest(n):
-        return FeedDataModel.query.order_by(FeedDataModel.timestamp.desc()).limit(n).all()
+    def get_latest(limit, offset):
+        return FeedDataModel.query.order_by(FeedDataModel.timestamp.desc()).limit(limit).offset(offset).all()
 
 
 class FeedSchema(Schema):

--- a/src/views/FeedView.py
+++ b/src/views/FeedView.py
@@ -34,12 +34,20 @@ def feed_request():
     return custom_response(feed_data, 200)  # return data
 
 
-@feed_api.route('/latest/<int:n>', methods=['GET'])
-def get_latest(n):
+@feed_api.route('/latest', methods=['GET'])
+def get_latest():
+    limit = request.args.get('limit', None)
+    offset = request.args.get('offset', None)
     try:
-        feed_elements = FeedDataModel.get_latest(n)
+        limit = int(limit)
+        offset = int(offset)
+        feed_elements = FeedDataModel.get_latest(limit, offset)
     except OperationalError as e:
         return custom_response(str(e), 400)
+    except (ValueError, TypeError):
+        return custom_response(
+            "Cannot parse provided values for limit=" + str(limit) + " and offset=" + str(offset) +
+            ". Please ensure that both values are of type 'int'.", 400)
 
     if not feed_elements:
         return custom_response([], 400)


### PR DESCRIPTION
Resolves #9 

**NOTE:**
This changes the api query for the call on `latest`. Instead of `latest/10` for the latest 10 entries, the call for the latest 10 entries without any offset (= page 0) now needs to be `latest?limit=10&offset=0`. 
@schliflo if you prefer keeping also the old way of getting n elements without offset without providing `offset=0` pls let me know. I'll add this functionality then as well. 